### PR TITLE
GitHub hygiene: issue forms, PR template, Dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a reproducible GTV2STREAM problem
+title: "[BUG] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please include the launcher payload/logcat output when possible; provider-specific Google TV payloads are especially useful.
+  - type: input
+    id: version
+    attributes:
+      label: GTV2STREAM version
+      placeholder: e.g. 1.1.0
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: TV / device
+      placeholder: e.g. TCL Google TV, Chromecast with Google TV
+    validations:
+      required: true
+  - type: input
+    id: android
+    attributes:
+      label: Android / Google TV version
+      placeholder: e.g. Android 14
+  - type: dropdown
+    id: target
+    attributes:
+      label: Redirect target
+      options:
+        - Nuvio
+        - Stremio
+        - SmartTube
+        - Other / not applicable
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you click, what did you expect, and what actually happened?
+      placeholder: |
+        1. Open Google TV home screen
+        2. Select ...
+        3. GTV2STREAM ...
+    validations:
+      required: true
+  - type: textarea
+    id: payload
+    attributes:
+      label: Launcher payload / logs
+      description: Paste relevant ADB logcat lines or accessibility payload text. Remove anything you consider private.
+      render: text
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Screenshots, provider name, title, or anything else that may help.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I checked ROADMAP.md and existing issues first.
+          required: true
+        - label: This report does not include a TMDB API key or other secret.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Roadmap
+    url: https://github.com/xantipater/GTV2STREAM/blob/main/ROADMAP.md
+    about: Check supported, in-progress, and investigated features before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest an improvement to GTV2STREAM
+title: "[FEATURE] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check ROADMAP.md first. GTV2STREAM is local-first: features that require viewing data to leave the device are out of scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that GTV2STREAM does not currently support?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: Describe the expected behaviour as concretely as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Example flow
+      placeholder: |
+        Given: ...
+        When: ...
+        Then: ...
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Relevant apps, devices, provider behaviour, or screenshots.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I checked ROADMAP.md and existing issues first.
+          required: true
+        - label: This request is compatible with the project's local-first/privacy principles.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+Describe what changed and why.
+
+## Testing
+
+- [ ] `./gradlew :app:runHelperTests`
+- [ ] `./gradlew :app:lintDebug`
+- [ ] `./gradlew :app:assembleDebug`
+- [ ] Tested on a real Google TV / Android TV device where relevant
+
+## Behaviour / privacy checks
+
+- [ ] No viewing data, credentials, or telemetry leave the device beyond the services explicitly used by the feature
+- [ ] No TMDB API keys, signing material, tokens, or other secrets are included
+- [ ] Launcher parsing changes include regression coverage for the payload being fixed
+- [ ] Documentation / changelog updated when user-visible behaviour changed
+
+## Related issue
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds repository-only housekeeping with no application behaviour changes:

- structured bug report form with device/version/payload fields
- structured feature request form aligned to the local-first project principles
- PR checklist covering tests, privacy, secrets and parser regression coverage
- weekly Dependabot checks for Gradle and GitHub Actions
- issue chooser linking to the roadmap

Closes #3.